### PR TITLE
Update path to AudioLink shader to be compatible with AudioLink VPM package

### DIFF
--- a/Assets/_Aurora/Aurora.shader
+++ b/Assets/_Aurora/Aurora.shader
@@ -46,7 +46,7 @@
             #define AUDIOLINK
             #endif
             #ifdef AUDIOLINK
-            #include "../../AudioLink/Shaders/AudioLink.cginc"
+            #include "../../../Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc"
             #endif
 
             float _Speed, _ColSpeed, _ScaleDown, _OpacityMod, _Reactive, _Height;


### PR DESCRIPTION
Updated the path to the AudioLink shader file, so it works with the AudioLink VPM package.